### PR TITLE
Se soluciona el "terminate called without an active exception"

### DIFF
--- a/src/server/Game.cpp
+++ b/src/server/Game.cpp
@@ -4,6 +4,9 @@ Game::Game() : status(Game_status::WAITING) {
     entity_pool.push_back(std::make_unique<Player>(0, 0, 0));
 }
 
+// Agregado para poder parar el loop del servidor, antes de joinear este thread
+void Game::stop() { status = Game_status::STOPPED; }
+
 void Game::run() {
     status = Game_status::RUNNING;
     std::chrono::steady_clock::time_point INICIO_ABSOLUTO = reloj.now();

--- a/src/server/Game.h
+++ b/src/server/Game.h
@@ -29,6 +29,7 @@ class Game : public Thread {
     void run() override;
     void run_iteration();
     void process_action(uint8_t action, int player);
+    void stop() override;
 };
 
 #endif  // GAME_H

--- a/src/server/clients/client_monitor.cpp
+++ b/src/server/clients/client_monitor.cpp
@@ -11,3 +11,11 @@ void Client_Monitor::sendAll(std::vector<Update> updates) {
         i->getSender().addToQueue(updates);
     }
 }
+
+Client_Monitor::~Client_Monitor() {
+    // Agregado destructor para los puntero a erver_Client
+    while (Client_Monitor::list.size() > 0) {
+        delete Client_Monitor::list.back();
+        Client_Monitor::list.pop_back();
+    }
+}

--- a/src/server/clients/client_monitor.h
+++ b/src/server/clients/client_monitor.h
@@ -14,6 +14,7 @@ class Client_Monitor {
     static Server_Client* get(int i);
     static void sendAll(std::vector<Update> updates);
     static std::vector<Server_Client*> getAll() { return list; }
+    ~Client_Monitor();
 };
 
 #endif  // CLIENT_MONITOR_H

--- a/src/server/server_main.cpp
+++ b/src/server/server_main.cpp
@@ -27,4 +27,14 @@ int main(int argc, char* argv[]) {
     do {
         std::cin >> input;
     } while (input != "q");
+
+    // Se para y joinea los threads del listener y game
+
+    listener.kill();
+
+    listener.stop();
+    listener.join();
+
+    game.stop();
+    game.join();
 }


### PR DESCRIPTION
El pull request soluciona el error que se devolvía al cerrar el servidor.

Era generado por los threads de game y listener no joineados.

Tambien, para evitar problemas futuros, se agrego un destructor al client monitor, para que destruya correctamente los punteros que almacenaba.