### PR TITLE
Modificado la clase Thread.

### DIFF
--- a/src/client/eventlistener.h
+++ b/src/client/eventlistener.h
@@ -18,6 +18,8 @@ class EventListener : public Thread {
     ClientProtocol protocol;
     Mapper mapper;
 
+    std::string text_description() override { return "EventListenerCliente"; }
+
     void process_event(const SDL_Event& event, bool& running);
 
    public:

--- a/src/client/gui/gui_loop.h
+++ b/src/client/gui/gui_loop.h
@@ -26,6 +26,8 @@ class GuiLoop : public Thread {
 
     uint32_t tick_actual;
 
+    std::string text_description() override { return "GuiLoop cliente"; }
+
    public:
     // GuiLoop();
     explicit GuiLoop(Window& window);

--- a/src/client/updater.cpp
+++ b/src/client/updater.cpp
@@ -3,13 +3,10 @@
 Updater::Updater(Socket& socket) : protocol(socket) {}
 
 void Updater::run() {
-    while (is_running) {
+    while (this->keep_running()) {
         std::vector<Update> updated_info = protocol.receive_ticks();
         Update_queue::push(updated_info);
     }
 }
 
-void Updater::stop() {
-    this->is_running = false;
-    protocol.kill();
-}
+void Updater::stop_custom() { protocol.kill(); }

--- a/src/client/updater.h
+++ b/src/client/updater.h
@@ -13,7 +13,8 @@
 class Updater : public Thread {
    private:
     ClientProtocol protocol;
-    bool is_running = true;
+
+    std::string text_description() override { return "Updater Cliente"; }
 
    public:
     explicit Updater(Socket& socket);
@@ -21,7 +22,7 @@ class Updater : public Thread {
     // envia la informacion actualizada al
     void run() override;
 
-    void stop() override;
+    void stop_custom() override;
 };
 
 #endif  // UPDATER_H

--- a/src/common/library/thread.h
+++ b/src/common/library/thread.h
@@ -1,61 +1,102 @@
 #ifndef THREAD_H_
 #define THREAD_H_
 
+// Para usar el gettid()
+#include <sys/syscall.h>
+#include <unistd.h>
+
 #include <atomic>
 #include <iostream>
 #include <thread>
 
+#define gettid() syscall(SYS_gettid)
+
 class Runnable {
-public:
+   public:
     virtual void start() = 0;
     virtual void join() = 0;
     virtual void stop() = 0;
     virtual bool is_alive() const = 0;
+    virtual bool keep_running() const = 0;
 
     virtual ~Runnable() {}
 };
 
-class Thread: public Runnable {
-private:
+class Thread : public Runnable {
+   private:
     std::thread thread;
 
-protected:
+   protected:
     // Subclasses that inherit from Thread will have access to these
     // flags, mostly to control how Thread::run() will behave
     std::atomic<bool> _keep_running;
     std::atomic<bool> _is_alive;
 
-public:
-    Thread(): _keep_running(true), _is_alive(false) {}
+    // Funcion que implementan quienes heredan de Thread. Es lo que se ejecuta
+    // para parar forzozamente al hilo en cuestion. Esta funcion no es llamada
+    // desde fuera, unicamente desde Thread
+    virtual void stop_custom() {}
 
-    void start() override {
-        _is_alive = true;
-        _keep_running = true;
-        thread = std::thread(&Thread::main, this);
-    }
+    // Funcion que implementan quienes heredan de Thread. Se usa para, si se
+    // genera una excepcion, tener una descripcion de texto de cual tipo de
+    // Thread devolvió el error. (vease main)
+    virtual std::string text_description() = 0;
 
-    void join() override { thread.join(); }
+    // Convertí los siguientes 3 metodos en protected, para que no se pueda, por
+    // ejemplo, intentar iniciar un implementador de thread con "run()"
+    Thread() : _keep_running(true), _is_alive(false) {}
 
     void main() {
         try {
+#ifndef NDEBUG
+            std::cout << "Inicia hilo de " << text_description()
+                      << " con PID: " << gettid() << std::endl;
+#endif
+
             this->run();
         } catch (const std::exception& err) {
-            std::cerr << "Unexpected exception: " << err.what() << "\n";
+            std::cerr << "Unexpected exception in " << text_description()
+                      << ": " << err.what() << "\n";
         } catch (...) {
-            std::cerr << "Unexpected exception: <unknown>\n";
+            std::cerr << "Unexpected exception in " << text_description()
+                      << ": <unknown>\n";
         }
 
         _is_alive = false;
     }
 
+    virtual void run() = 0;
+
+   public:
+    void start() override final {
+        _is_alive = true;
+        _keep_running = true;
+        thread = std::thread(&Thread::main, this);
+    }
+
+    void join() override final { thread.join(); }
+
     // Note: it is up to the subclass to make something meaningful to
     // really stop the thread. The Thread::run() may be blocked and/or
     // it may not read _keep_running.
-    void stop() override { _keep_running = false; }
+
+    // Implementar la parte custom en stop_custom()
+    void stop() override final {
+        // Pongo para que deje de ejecutarse
+        _keep_running = false;
+
+        // Hago yield para darle la oportunidad de que se detenga.
+        std::this_thread::yield();
+
+        // Luego del yield checkeo si el thread ya terminó, si no terminó,
+        // ejecuto la funcion stop_custom, que debería considerar que el hilo
+        // pueda estar bloqueado en un recurso, y pararlo forzosamente
+        if (_is_alive) stop_custom();
+    }
 
     bool is_alive() const override { return _is_alive; }
+    bool keep_running() const override { return _keep_running; }
 
-    virtual void run() = 0;
     virtual ~Thread() {}
 
     Thread(const Thread&) = delete;

--- a/src/server/Game.cpp
+++ b/src/server/Game.cpp
@@ -5,7 +5,7 @@ Game::Game() : status(Game_status::WAITING) {
 }
 
 // Agregado para poder parar el loop del servidor, antes de joinear este thread
-void Game::stop() { status = Game_status::STOPPED; }
+void Game::stop_custom() { status = Game_status::STOPPED; }
 
 void Game::run() {
     status = Game_status::RUNNING;

--- a/src/server/Game.h
+++ b/src/server/Game.h
@@ -24,12 +24,14 @@ class Game : public Thread {
     Game_status status;
     std::vector<std::unique_ptr<Dynamic_entity>> entity_pool;
 
+    std::string text_description() override { return "Game server"; }
+
    public:
     explicit Game();
     void run() override;
     void run_iteration();
     void process_action(uint8_t action, int player);
-    void stop() override;
+    void stop_custom() override;
 };
 
 #endif  // GAME_H

--- a/src/server/clients/client_listener.h
+++ b/src/server/clients/client_listener.h
@@ -15,6 +15,8 @@ class Client_listener : public Thread {
     Socket skt_listener;
     bool is_running;
 
+    std::string text_description() override { return "Client_listener server"; }
+
    public:
     explicit Client_listener(char* port)
         : skt_listener(port), is_running(true) {}

--- a/src/server/clients/server_client.h
+++ b/src/server/clients/server_client.h
@@ -16,6 +16,8 @@ class Client_receiver : public Thread {
     Queue<ActionType> inputQueue;
     bool is_running;
 
+    std::string text_description() override { return "Client_reciever server"; }
+
    public:
     explicit Client_receiver(Socket& socket)
         : protocol(socket), inputQueue(), is_running(true) {}
@@ -30,6 +32,8 @@ class Client_sender : public Thread {
     Protocol protocol;
     Queue<std::vector<Update>> outputQueue;
     bool is_running;
+
+    std::string text_description() override { return "Client_sender server"; }
 
    public:
     explicit Client_sender(Socket& socket)


### PR DESCRIPTION
Se modifico cuales metodos son publicos y cuales protegidos, para prevenir bugs donde, por ejemplo, se llama a run en vez de start. Tambien agrego un metodo que devuelve una descripcion de texto del thread actual. Esto lo uso para, en el caso de que se lanze una excepcion, se imprima que implementor de thread la lanzó.

Además modifico la funcion de stop, para que solo llame al stop custom si es necesario (y para estandarizar el uso de keep_running)

Por ultimo, si la compilacion es debug, al iniciar un hilo imprimo el pid, por si hay problemas con uso de recursos en un thread, poder identificarlo a partir del pid.

Modifique todos los implementores de Thread para que sean compliant con los nuevos requisitos.